### PR TITLE
Orders elements of train.py logically

### DIFF
--- a/maxwell/train.py
+++ b/maxwell/train.py
@@ -8,6 +8,36 @@ import click
 from . import sed, util
 
 
+def _get_cell(row: List[str], col: int, sep: str) -> List[str]:
+    """Returns the split cell of a row.
+    Args:
+        row (List[str]): the split row.
+        col (int): the column index
+        sep (str): the string to split the column on; if the empty string,
+            the column is split into characters instead.
+    Returns:
+        A list of symbols from that cell.
+    """
+    cell = row[col - 1]  # -1 because we're using one-based indexing.
+    return list(cell) if not sep else cell.split(sep)
+
+
+def _get_samples(
+    filename: str,
+    source_col: int,
+    source_sep: str,
+    target_col: int,
+    target_sep: str,
+):
+    with open(filename, "r") as source:
+        tsv_reader = csv.reader(source, delimiter="\t")
+        for row in tsv_reader:
+            source = _get_cell(row, source_col, source_sep)
+            target = _get_cell(row, target_col, target_sep)
+            # Adds third item for compatibility with yoyodyne dataloader.
+            yield source, target
+
+
 @click.command()
 @click.option("--train-data-path", required=True)
 @click.option("--source-col", type=int, default=1)
@@ -39,7 +69,7 @@ def main(
     util.log_info("Arguments:")
     for arg, val in click.get_current_context().params.items():
         util.log_info(f"\t{arg}: {val!r}")
-    train_samples = get_samples(
+    train_samples = _get_samples(
         train_data_path,
         source_col,
         source_sep,
@@ -50,36 +80,6 @@ def main(
         train_samples, epochs=num_epochs
     )
     sed_aligner.params.write_params(output_path)
-
-
-def get_samples(
-    filename: str,
-    source_col: int,
-    source_sep: str,
-    target_col: int,
-    target_sep: str,
-):
-    with open(filename, "r") as source:
-        tsv_reader = csv.reader(source, delimiter="\t")
-        for row in tsv_reader:
-            source = _get_cell(row, source_col, source_sep)
-            target = _get_cell(row, target_col, target_sep)
-            # Adds third item for compatibility with yoyodyne dataloader.
-            yield source, target
-
-
-def _get_cell(row: List[str], col: int, sep: str) -> List[str]:
-    """Returns the split cell of a row.
-    Args:
-        row (List[str]): the split row.
-        col (int): the column index
-        sep (str): the string to split the column on; if the empty string,
-            the column is split into characters instead.
-    Returns:
-        A list of symbols from that cell.
-    """
-    cell = row[col - 1]  # -1 because we're using one-based indexing.
-    return list(cell) if not sep else cell.split(sep)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This simple PR just orders the pieces of train.py logically, so that things are declared before they are used. No other changes are made. Of coures Python doesn't require this but I think it's preferable.