### PR TITLE
Migrates to argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ dependency.
 For command-line use, run:
 
     maxwell-train \
-        --train-data-path /path/to/train/data \
-        --output-path /path/to/output/file \
-        --num-epoch "${NUM_EPOCHS}"
+        --train /path/to/train/data \
+        --output /path/to/output/file \
+        --epochs "${NUM_EPOCHS}"
 
 As a library object, you can use the `StochasticEditDistance` class to pass any
 iterable of source-target pairs for training. Learned edit weights can then be
@@ -70,7 +70,7 @@ learned optimal sequence and the weight given to the sequence:
 from maxwell import sed
 
 
-params = sed.ParamsDict.read_params("/path/to/learned/parameters/")
+params = sed.ParamsDict.read_params("/path/to/learned/parameters")
 aligner = sed.StochasticEditDistance(params)
 optimal_sequence, optimal_cost = aligner.action_sequence(source, target)
 ```

--- a/maxwell/train.py
+++ b/maxwell/train.py
@@ -1,9 +1,8 @@
-"""Training."""
+"""Stochastic edit distance training."""
 
+import argparse
 import csv
-from typing import List
-
-import click
+from typing import Iterator, List, Tuple
 
 from . import sed, util
 
@@ -28,24 +27,15 @@ def _get_samples(
     source_sep: str,
     target_col: int,
     target_sep: str,
-):
+) -> Iterator[Tuple[str, str]]:
     with open(filename, "r") as source:
         tsv_reader = csv.reader(source, delimiter="\t")
         for row in tsv_reader:
             source = _get_cell(row, source_col, source_sep)
             target = _get_cell(row, target_col, target_sep)
-            # Adds third item for compatibility with yoyodyne dataloader.
             yield source, target
 
 
-@click.command()
-@click.option("--train-data-path", required=True)
-@click.option("--source-col", type=int, default=1)
-@click.option("--target-col", type=int, default=2)
-@click.option("--source-sep", type=str, default="")
-@click.option("--target-sep", type=str, default="")
-@click.option("--output-path", required=True)
-@click.option("--num-epochs", type=int, default=10)
 def main(
     train_data_path,
     source_col,
@@ -55,19 +45,18 @@ def main(
     output_path,
     num_epochs,
 ):
-    """Training.
-
-    Args:
-        train_data_path (_type_): _description_
-        source_col (_type_): _description_
-        target_col (_type_): _description_
-        source_sep (_type_): _description_
-        target_sep (_type_): _description_
-        output_path (_type_): _description_
-        num_epochs (_type_): _description_
-    """
+    """Training."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--train", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--source_col", type=int, default=1)
+    parser.add_argument("--target_col", type=int, default=2)
+    parser.add_argument("--source_sep", type=str, default="")
+    parser.add_argument("--target_sep", type=str, default="")
+    parser.add_argument("--epochs", type=int, default=10)
+    args = parser.parser_args()
     util.log_info("Arguments:")
-    for arg, val in click.get_current_context().params.items():
+    for arg, val in vars(args).items():
         util.log_info(f"\t{arg}: {val!r}")
     train_samples = _get_samples(
         train_data_path,

--- a/maxwell/train.py
+++ b/maxwell/train.py
@@ -36,15 +36,7 @@ def _get_samples(
             yield source, target
 
 
-def main(
-    train_data_path,
-    source_col,
-    target_col,
-    source_sep,
-    target_sep,
-    output_path,
-    num_epochs,
-):
+def main() -> None:
     """Training."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--train", required=True)
@@ -59,16 +51,16 @@ def main(
     for arg, val in vars(args).items():
         util.log_info(f"\t{arg}: {val!r}")
     train_samples = _get_samples(
-        train_data_path,
-        source_col,
-        source_sep,
-        target_col,
-        target_sep,
+        args.train,
+        args.source_col,
+        args.source_sep,
+        args.target_col,
+        args.target_sep,
     )
     sed_aligner = sed.StochasticEditDistance.fit_from_data(
-        train_samples, epochs=num_epochs
+        train_samples, epochs=args.epochs
     )
-    sed_aligner.params.write_params(output_path)
+    sed_aligner.params.write_params(args.output)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 black>=22.3.0
-click>=8.1.3
 flake8>=3.9.2
 numpy>=1.20.1
 scipy>=1.6

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(os.path.join(_THIS_DIR, "README.md")) as f:
     _LONG_DESCRIPTION = f.read().strip()
 
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 
 def main() -> None:
@@ -47,7 +47,6 @@ def main() -> None:
         license="Apache 2.0",
         python_requires=">=3.9",
         install_requires=[
-            "click>=8.1.3",
             "numpy>=1.20.1",
             "scipy>=1.6",
             "tqdm>=4.64.1",


### PR DESCRIPTION
This just moves maxwell from third-party `click` to standard library `argparse` and thus reduces Yoyodyne's dependencies as well. 

The argument names are also matched with `yoyodyne-train` for compatibility.

I also add some drive-by typing in one place and remove a stale comment.