### PR TITLE
replaces scipy.logsumexp with numpy.logaddexp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["maxwell*"]
 
 [project]
 name = "maxwell"
-version = "0.2.2.post2"
+version = "0.2.3"
 description = "Stochastic Edit Distance aligenr for string transduction"
 readme = "README.md"
 requires-python = "> 3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ keywords = [
 ]
 dependencies = [
     "numpy >= 1.20.1",
-    "scipy >= 1.6",
     "tqdm >= 4.64.1",
 ]
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ build>=0.10.0
 flake8>=3.9.2
 numpy>=1.20.1
 pytest>=7.4.0
-scipy>=1.6
 twine>=4.0.2
 tqdm>=4.64.1


### PR DESCRIPTION
I was testing the yoyodyne Transducer and was just curious if there was any low-hanging fruit to make this faster. I ran a script for 2 epochs on inflection data with cProfile to compare these two methods.

With scipy.special.logsumexp (sorted by tottime):

```
         28068773 function calls (28064110 primitive calls) in 31.645 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   612792    8.368    0.000   28.165    0.000 _logsumexp.py:7(logsumexp)
  1225593    3.793    0.000    3.793    0.000 {method 'reduce' of 'numpy.ufunc' objects}
  1225598    1.793    0.000    4.141    0.000 _ufunc_config.py:33(seterr)
  1225590    1.740    0.000    6.328    0.000 fromnumeric.py:69(_wrapreduction)
   612792    1.629    0.000    2.850    0.000 _util.py:241(_asarray_validated)
  1225598    1.436    0.000    1.612    0.000 _ufunc_config.py:132(geterr)
     3000    1.319    0.000   14.786    0.005 sed.py:212(forward_evaluate)
1842405/1842386    1.225    0.000    9.557    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
     1000    0.739    0.001   21.056    0.021 sed.py:339(e_step)
...
```

with numpy.logaddexp:

```
         2718346 function calls (2716040 primitive calls) in 3.170 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   611801    1.441    0.000    1.441    0.000 {method 'reduce' of 'numpy.ufunc' objects}
     3000    0.777    0.000    1.647    0.001 sed.py:212(forward_evaluate)
     1000    0.302    0.000    1.879    0.002 sed.py:339(e_step)
     1000    0.246    0.000    0.523    0.001 sed.py:255(backward_evaluate)
   966650    0.112    0.000    0.112    0.000 {method 'get' of 'dict' objects}
   972913    0.078    0.000    0.078    0.000 {method 'append' of 'list' objects}
    40/38    0.029    0.001    0.031    0.001 {built-in method _imp.create_dynamic}
      136    0.013    0.000    0.013    0.000 {built-in method marshal.loads}
4029/4010    0.009    0.000    0.010    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
...
```

I did not really read docs about any potential issues and will test this tomorrow on more data to make sure there are no numerical stability issues. But I like the 10X performance increase :).