### PR TITLE
Improves progress bars.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["maxwell*"]
 [project]
 name = "maxwell"
 version = "0.2.4"
-description = "Stochastic Edit Distance aligenr for string transduction"
+description = "Stochastic Edit Distance aligner for string transduction"
 readme = "README.md"
 requires-python = "> 3.9"
 license = { text = "Apache 2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["maxwell*"]
 
 [project]
 name = "maxwell"
-version = "0.2.3.post1"
+version = "0.2.4"
 description = "Stochastic Edit Distance aligenr for string transduction"
 readme = "README.md"
 requires-python = "> 3.9"


### PR DESCRIPTION
This makes the two progress bars match roughly what is done in Lightning, with an implementation inspired by Lightning's.

The basic idea is that the primary bar is the one making the pass over the data during the e-step; a secondary bar is generated immediately when we compute loss during the (so-called) validation step; then the loss from that validation is reported as a "postfix" of the primary bar.