### PR TITLE
udated unit tests

### DIFF
--- a/maxwell/sed.py
+++ b/maxwell/sed.py
@@ -309,7 +309,7 @@ class StochasticEditDistance(abc.ABC):
         loss = numpy.inf
         gammas = ParamDict.from_params(self.params)
         train_pb = util.TrainProgressBar(len(sources))
-        val_pb = util.ValidationProgressBar(len(sources))
+        val_pb = util.ValidationProgressBar(len(sources)) if validate else None
         util.log_info(f"Performing {epochs} epochs of EM")
         for epoch in range(epochs):
             train_pb.on_epoch_start(epoch=epoch)
@@ -321,7 +321,9 @@ class StochasticEditDistance(abc.ABC):
             if validate:
                 loss = self.validation_pass(sources, targets, val_pb)
             train_pb.on_epoch_end(loss=-loss)
-        train_pb.on_end(), val_pb.on_end()
+        train_pb.on_end()
+        if validate:
+            val_pb.on_end()
 
     def validation_pass(
         self,

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -76,9 +76,10 @@ class TestSed(unittest.TestCase):
             -1, -1
         ]  # Stochastic edit distance.
         util.log_info(o)
-        before_ll = sed_.log_likelihood(sources, targets)
+        val_pb = util.ValidationProgressBar(len(sources))
+        before_ll = sed_.validation_pass(sources, targets, val_pb=val_pb)
         sed_.em(sources, targets, epochs=1)
-        after_ll = sed_.log_likelihood(sources, targets)
+        after_ll = sed_.validation_pass(sources, targets, val_pb=val_pb)
         self.assertTrue(before_ll <= after_ll)
 
     def test_fit_from_data(self):


### PR DESCRIPTION
Fixes broken unit tests.

Since validate makes the validation pass optional, there was an edge case where we tried to close the validation bar when it had never opened. This adds flag checks around to avoid the break.