### PR TITLE
Updates `fit_from_data` internals

### DIFF
--- a/maxwell/sed.py
+++ b/maxwell/sed.py
@@ -174,7 +174,7 @@ class StochasticEditDistance(abc.ABC):
     @classmethod
     def fit_from_data(
         cls,
-        lines: Iterable[Tuple[Any]],
+        lines: Iterable[Tuple[str, str]],
         copy_probability: Optional[float] = None,
         epochs: int = 10,
         validate: bool = False,
@@ -194,14 +194,11 @@ class StochasticEditDistance(abc.ABC):
         target_alphabet = set()
         sources = []
         targets = []
-        for line in lines:
-            # Split lines manually to ignore features from yoyodyne.
-            s = line[0]
-            t = line[1]
-            source_alphabet.update(s)
-            target_alphabet.update(t)
-            sources.append(s)
-            targets.append(t)
+        for source, target in lines:
+            source_alphabet.update(source)
+            target_alphabet.update(target)
+            sources.append(source)
+            targets.append(target)
         sed = cls.build_sed(source_alphabet, target_alphabet, copy_probability)
         sed.em(sources, targets, epochs, validate)
         return sed

--- a/maxwell/sed.py
+++ b/maxwell/sed.py
@@ -174,15 +174,18 @@ class StochasticEditDistance(abc.ABC):
     @classmethod
     def fit_from_data(
         cls,
-        lines: Iterable[Tuple[str, str]],
+        data: Iterable[Tuple[Any, Any]],
         copy_probability: Optional[float] = None,
         epochs: int = 10,
         validate: bool = False,
     ) -> StochasticEditDistance:
         """Fits StochasticEditDistance parameters from data.
 
+        The elements in the data tuple are usually strings but can be any
+        hashable type.
+
         Args:
-            lines (Iterable[Tuple[Any]]): source and target strings.
+            data (Iterable[Tuple[Any, Any]]): source and target strings.
             copy_probability (Optional[float]): default probability mass for
                 copy edits.
             epochs (int): number of EM epochs.
@@ -194,7 +197,7 @@ class StochasticEditDistance(abc.ABC):
         target_alphabet = set()
         sources = []
         targets = []
-        for source, target in lines:
+        for source, target in data:
             source_alphabet.update(source)
             target_alphabet.update(target)
             sources.append(source)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["maxwell*"]
 
 [project]
 name = "maxwell"
-version = "0.2.5"
+version = "0.2.6"
 description = "Stochastic Edit Distance aligner for string transduction"
 readme = "README.md"
 requires-python = ">= 3.9"

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -85,7 +85,7 @@ class TestSed(unittest.TestCase):
     def test_fit_from_data(self):
         def _to_sample(line: str):
             input_, target = line.rstrip().split("\t", 1)
-            return input_, target, None
+            return input_, target
 
         input_lines = [
             "abby\ta b i",


### PR DESCRIPTION
This is out of date in two ways:

* Yoyodyne doesn't directly feed in the output of the TSV reader, it already has [separate logic](https://github.com/CUNY-CL/yoyodyne/blob/570c292222934327ee859e9b70388226eb993c21/yoyodyne/models/expert.py#L460) to handle that.
* The subscripting wouldn't help even if it was because the subscripts are wrong for that case.